### PR TITLE
Upgrade Stitches 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@sentry/tracing": "^6.3.1",
     "@sentry/webpack-plugin": "^1.15.1",
     "@state-designer/react": "^1.7.1",
-    "@stitches/react": "^0.1.9",
+    "@stitches/react": "^0.2.2",
     "@supabase/supabase-js": "^1.11.6",
     "add": "^2.0.6",
     "chrome-aws-lambda": "^8.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1949,17 +1949,10 @@
   dependencies:
     "@state-designer/core" latest
 
-"@stitches/core@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@stitches/core/-/core-0.1.9.tgz#6cc42ae6052f6900f9add164232449ff8d62c4ba"
-  integrity sha512-70gVb0uhgV6BOJmloirWEGZmofk/Hzr5yWlub1rtm4CvimD3Xl5xr9fVkjcTu+REC6ILCJCnlEP4WmilTfXNOA==
-
-"@stitches/react@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-0.1.9.tgz#b16e05c9ee7e34369bb3b051b92a997ab379863f"
-  integrity sha512-yK4ZAdkuOiOum+bfPYlDNS9UI/Tm9JYsYNMUWLB3uAy+7tvSYfB4cVYkXwFuiKxis03woATTZTe6IlTb+LXm+A==
-  dependencies:
-    "@stitches/core" "^0.1.9"
+"@stitches/react@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-0.2.2.tgz#8a2f8256835510c265ab20820f54a5bb0376bac6"
+  integrity sha512-/qRSX+ANPJg/0eLNr5bEywjkdvIfLbsaG2d8p83wPlI0MA7Yi9FzaRLk2H6DMAdJHuyu6ThY4HfHQIL35buY9g==
 
 "@supabase/gotrue-js@^1.13.1":
   version "1.13.1"


### PR DESCRIPTION
Hey, this PR upgrades Stitches to the latest version for improved performance. 

I couldn't get this running locally anymore, but everything should work fine, as there were no breaking changes impacted by this change.